### PR TITLE
Fix typos in the `time` command output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Commands:
   map      Launch Openstreet map URL with the stop location
   status   Check if the Luas stop is operational
   stops    List luas line stop names and its abbreviations (used in other commands)
-  time     Display the the inbound/outbout timetable of a particualr luas stop
+  time     Display the inbound/outbound timetable of a particular luas stop
 ```
 
 ### Examples:

--- a/luascli/main.py
+++ b/luascli/main.py
@@ -126,7 +126,7 @@ def address(stop, format):
     help="Output format (Valid options: json/text)",
 )
 def time(stop, format):
-    """Display the the inbound/outbout timetable of a particualr luas stop"""
+    """Display the inbound/outbound timetable of a particular luas stop"""
 
     try:
         timetable = get_timetable(stop)


### PR DESCRIPTION
Fixed:

* outbout -> outbound
* particulr -> particular
* the the -> the
